### PR TITLE
Disable arm64 container builds in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ github.ref == 'refs/heads/main' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: ghcr.io/twizmwazin/app-controller/${{ matrix.container.name }}
           context: ${{ matrix.container.path }}


### PR DESCRIPTION
Will still publish them, but skip building them because it takes forever